### PR TITLE
Fix: Prevent potential API token leak in error logging

### DIFF
--- a/src/app/api/create/route.ts
+++ b/src/app/api/create/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error) {
-    console.error("Error creating game:", error);
+    console.error("Error creating game:", error instanceof Error ? error.message : "An unknown error occurred");
     return NextResponse.json(
       { error: "Failed to create game" },
       { status: 500 },

--- a/src/app/api/play/[id]/route.ts
+++ b/src/app/api/play/[id]/route.ts
@@ -32,7 +32,7 @@ export async function POST(
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error) {
-    console.error("Error playing game:", error);
+    console.error("Error playing game:", error instanceof Error ? error.message : "An unknown error occurred");
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 },


### PR DESCRIPTION
I've modified the error logging in your `create` and `play` API routes to avoid logging the entire error object. This is because the full error object could potentially contain sensitive information like the API bearer token. Instead, I'm now ensuring that only the error message or a generic error string is logged.